### PR TITLE
gshellwrapper: Fails to find Shell when its version is not from numbe…

### DIFF
--- a/gtweak/gshellwrapper.py
+++ b/gtweak/gshellwrapper.py
@@ -90,14 +90,13 @@ class GnomeShellFactory:
         try:
             proxy = _ShellProxy()
             settings = GSettingsSetting("org.gnome.shell")
-            v = list(map(int, proxy.version.split(".")))
 
             self.shell = GnomeShell(proxy, settings)
 
-            logging.debug("Shell version: %s", str(v))
-        except:
+            logging.debug("Shell version: %s", proxy.version)
+        except Exception as e:
             self.shell = None
-            logging.warn("Shell not installed or running")
+            logging.warn("Shell not installed or running (error: %s)", e)
 
     def get_shell(self):
         return self.shell


### PR DESCRIPTION
…rs only (#344)

Some tabs are hidden when Tweaks is run out of GNOME Shell, but the detection of the Shell running also expects the version number being only from the numbers. Since GNOME changed its version numbering the version can be "40.beta" and similar, which breaks Tweaks' code.

As the version string was used only for a debug print, do not try to decode it and use it verbatim there.

The second part of this change adds a print about the reason why it failed to find the Shell running. It'll help with further debugging.

Closes https://gitlab.gnome.org/GNOME/gnome-tweaks/-/issues/344